### PR TITLE
fix runtime error of undefined symbol: xkb_x11_get_core_keyboard_device

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "electron-log": "^4.2.4",
     "electron-updater": "4.2.5",
     "font-list": "^1.4.5",
-    "iohook": "^0.9.0",
+    "iohook": "0.9.0",
     "lodash.compact": "^3.0.1",
     "lodash.flatten": "^4.4.0",
     "lodash.sum": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "electron-log": "^4.2.4",
     "electron-updater": "4.2.5",
     "font-list": "^1.4.5",
-    "iohook": "^0.7.2",
+    "iohook": "^0.9.0",
     "lodash.compact": "^3.0.1",
     "lodash.flatten": "^4.4.0",
     "lodash.sum": "^4.0.2",
@@ -116,7 +116,8 @@
     ],
     "platforms": [
       "win32",
-      "darwin"
+      "darwin",
+      "linux"
     ],
     "arches": [
       "x64"


### PR DESCRIPTION
accroding to iohook's PR info https://github.com/wilix-team/iohook/pull/279 and https://github.com/zbanks/iohook/commit/0f88b1ec485ef95474ce85889b55931f5fac8442

this PR addapt the 0.9.0 version ,which iohook team released after 2020-12-30 when the time zbanks/iohook fix PR accepted.

have tested under ubuntu 22.04 with iohook 0.9.0 , the deb installed CopyTranslator will start and no more occur the error :undefined symbol: xkb_x11_get_core_keyboard_device