### PR TITLE
fix: bundle dictionary engines for smart dictionary

### DIFF
--- a/src/common/dictionary/easy.ts
+++ b/src/common/dictionary/easy.ts
@@ -6,6 +6,19 @@ const engine_modules = {
   youdao: "eazydict-youdao",
 };
 
+function loadEngine(moduleName: string): Function {
+  switch (moduleName) {
+    case "eazydict-bing":
+      return require("eazydict-bing");
+    case "eazydict-google":
+      return require("eazydict-google");
+    case "eazydict-youdao":
+      return require("eazydict-youdao");
+    default:
+      throw Error(`Unknown dictionary module: ${moduleName}`);
+  }
+}
+
 export class EasyEngine extends WordEngine {
   engine_func?: Function;
   name: DictionaryType;
@@ -18,7 +31,7 @@ export class EasyEngine extends WordEngine {
     if (!this.engine_func) {
         const moduleName = engine_modules[this.name];
         if (moduleName) {
-            this.engine_func = require(moduleName);
+            this.engine_func = loadEngine(moduleName);
         } else {
             return Promise.reject({ words: words, code: -1, engine: this.name, error: "Engine not found" });
         }

--- a/tests/unit/dictionary-easy.spec.ts
+++ b/tests/unit/dictionary-easy.spec.ts
@@ -1,0 +1,88 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as ts from "typescript";
+
+const mockBingQuery = jest.fn();
+const mockGoogleQuery = jest.fn();
+const mockYoudaoQuery = jest.fn();
+
+jest.mock("eazydict-bing", () => mockBingQuery);
+jest.mock("eazydict-google", () => mockGoogleQuery);
+jest.mock("eazydict-youdao", () => mockYoudaoQuery);
+
+import { BingEngine, EasyEngine, YoudaoEngine } from "@/common/dictionary/easy";
+
+const dictionaryResponse = {
+  phonetics: [{ type: "美", value: "[test]" }],
+  translates: [{ type: "n", trans: "测试" }],
+  examples: [],
+  error: { code: 0 },
+  url: "https://example.com",
+};
+
+describe("EasyEngine", () => {
+  beforeEach(() => {
+    mockBingQuery.mockReset();
+    mockGoogleQuery.mockReset();
+    mockYoudaoQuery.mockReset();
+  });
+
+  const cases: Array<[string, () => EasyEngine, jest.Mock]> = [
+    ["bing", () => new BingEngine(), mockBingQuery],
+    ["google", () => new EasyEngine("google" as any), mockGoogleQuery],
+    ["youdao", () => new YoudaoEngine(), mockYoudaoQuery],
+  ];
+
+  it("declares dictionary modules as static webpack dependencies", () => {
+    const file = path.resolve(__dirname, "../../src/common/dictionary/easy.ts");
+    const source = ts.createSourceFile(
+      file,
+      fs.readFileSync(file, "utf8"),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS
+    );
+    const modules: string[] = [];
+
+    function visit(node: ts.Node) {
+      const argument = ts.isCallExpression(node)
+        ? node.arguments[0]
+        : undefined;
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "require" &&
+        node.arguments.length === 1 &&
+        argument &&
+        ts.isStringLiteral(argument)
+      ) {
+        modules.push(argument.text);
+      }
+      ts.forEachChild(node, visit);
+    }
+
+    visit(source);
+
+    expect(modules.sort()).toEqual([
+      "eazydict-bing",
+      "eazydict-google",
+      "eazydict-youdao",
+    ]);
+  });
+
+  it.each(cases)(
+    "loads the packaged %s dictionary module",
+    async (_, createEngine, query) => {
+      query.mockResolvedValue(dictionaryResponse);
+
+      const result = await createEngine().query("test word");
+
+      expect(query).toHaveBeenCalledWith("test word", {});
+      expect(result).toMatchObject({
+        words: "test word",
+        explains: dictionaryResponse.translates,
+        phonetics: dictionaryResponse.phonetics,
+      });
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- Load the Bing, Google, and Youdao dictionary packages through static `require` calls.
- Preserve the existing `engine_modules` mapping and public class/function names.
- Add regression coverage for webpack-visible dependencies and all three dictionary loaders.

## Root cause

The dictionary engine was loaded with `require(moduleName)`, where `moduleName` is resolved at runtime. Webpack cannot reliably collect those package dependencies from a variable, so the packaged Electron application omitted the dictionary implementations. Smart Dictionary was selected for one-to-three-word input, but the query returned no valid dictionary result and the UI continued to show the normal translation.

## Impact

Packaged builds can query the selected Bing or Youdao dictionary again and render phonetics and basic explanations when the source provides them. The existing Google dictionary entry remains bundled for compatibility.

Fixes #655

## Verification

- `yarn test:unit --runInBand tests/unit/dictionary-easy.spec.ts`
- `yarn eslint tests/unit/dictionary-easy.spec.ts`
- `yarn prettier --check tests/unit/dictionary-easy.spec.ts`
- Windows x64 production ZIP build and archive integrity check
- Compared the official v12.1.0 package with the fixed package using isolated portable configurations
- Verified Bing and Youdao with `budget`, plus two- and three-word queries (`look up`, `as a result`)
